### PR TITLE
fix e.target.tagName is undefined error

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1012,8 +1012,9 @@ class PainterroProc {
           ];
           const scale = this.getScale();
           this.curCord = [this.curCord[0] * scale, this.curCord[1] * scale];
-          if (e.target.tagName.toLowerCase() !== 'input' && e.target.tagName.toLowerCase() !== 'button'
-        && e.target.tagName.toLowerCase() !== 'i' && e.target.tagName.toLowerCase() !== 'select') {
+          if (typeof e.target.tagName !== "undefined" && e.target.tagName.toLowerCase() !== 'input'
+              && e.target.tagName.toLowerCase() !== 'button' && e.target.tagName.toLowerCase() !== 'i'
+              && e.target.tagName.toLowerCase() !== 'select') {
             if (!this.zoomButtonActive) e.preventDefault();
           }
         }


### PR DESCRIPTION
This error occured leaving the browser window with the mouse using the select (or any other draggable) tool.