### PR TITLE
Fix image jumping out of view during on-screen keyboard popup

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1261,7 +1261,7 @@ class PainterroProc {
 
   adjustSizeFull() {
     const ratio = this.wrapper.documentClientWidth / this.wrapper.documentClientHeight;
-    if (this.zoom === false) {
+    if (this.zoom === false && this.textTool.active === false) {
       if (this.size.w > this.wrapper.documentClientWidth ||
         this.size.h > this.wrapper.documentClientHeight) {
         const newRelation = ratio < this.size.ratio;


### PR DESCRIPTION
On Android device, when the text tool is used in the lower portion of image, on-screen keyboard that pops up moves edited picture out of view. Picture thus cannot be seen by the user and the text field is placed outside the picture. This fixes this behavior.

Fix #187